### PR TITLE
複数入っているnodejsをnvm経由の1つにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get -y install \
   libmysqld-dev \
   libpq-dev \
   libsqlite3-dev \
-  nodejs \
   rbenv \
   ruby-build \
   ruby-dev \


### PR DESCRIPTION
# 背景
rentio本体のブランチで`autoprefixer` gemのモジュール上げたところ、以下のイシューが発生したため、apt経由のnodejsを削除

https://github.com/ai/autoprefixer-rails/issues/144