### PR TITLE
Bundler 2 にアップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-buil
 ARG RUBYGEMS_VERSION=3.0.2
 RUN gem update --system "$RUBYGEMS_VERSION" && rm -r /root/.gem/ && rbenv rehash
 
-ARG BUNDLER_VERSION=1.17.1
+ARG BUNDLER_VERSION=2.0.1
 RUN gem install bundler -v ${BUNDLER_VERSION} && rbenv rehash
 
 ARG NODE_VERSION=8.9.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ARG RUBYGEMS_VERSION=3.0.2
 RUN gem update --system "$RUBYGEMS_VERSION" && rm -r /root/.gem/ && rbenv rehash
 
 ARG BUNDLER_VERSION=2.0.1
-RUN gem install bundler -v ${BUNDLER_VERSION} && rbenv rehash
+RUN gem install bundler -v "${BUNDLER_VERSION}" --force && rbenv rehash
 
 ARG NODE_VERSION=8.9.4
 ENV NVM_DIR=/root/.nvm

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-buil
   && rbenv install ${RUBY_VERSION} \
   && rbenv global ${RUBY_VERSION}
 
+ARG RUBYGEMS_VERSION=3.0.2
+RUN gem update --system "$RUBYGEMS_VERSION" && rm -r /root/.gem/ && rbenv rehash
+
 ARG BUNDLER_VERSION=1.17.1
 RUN gem install bundler -v ${BUNDLER_VERSION} && rbenv rehash
 


### PR DESCRIPTION
# 変更内容

- Rubygems 3.0.2 にアップデート （Bundler 2 が Rubygems 3 以上に対応のため）
- Bundler 2.0.1 にアップデート

# 動作確認

```
# ビルドに成功することを確認
$ docker build .
...
Successfully built f30558e55032

# コンテナに入る
$ docker run -it f30558e55032 /bin/bash

# Rubygems のバージョンを確認
root@f20d3125f292:/app# gem --version
3.0.2

# Bundler のバージョンを確認
root@f20d3125f292:/app# bundler --version
Bundler version 2.0.1
```